### PR TITLE
Fix for rare crash when update happens as a train is leaving

### DIFF
--- a/src/trains.py
+++ b/src/trains.py
@@ -32,7 +32,11 @@ def prepareLocationName(location, show_departure_time):
         return location_name
     else:
         scheduled_time = location["lt7:st"]
-        expected_time = location["lt7:et"]
+        try:
+            expected_time = location["lt7:et"]
+        except KeyError:
+            # as per api docs, it's 'at' if there isn't an 'et':
+            expected_time = location["lt7:at"]
         departure_time = expected_time if isTime(expected_time) else scheduled_time
         formatted_departure = joinWith(["(", departure_time, ")"], "")
         return joinWithSpaces(location_name, formatted_departure)


### PR DESCRIPTION
Was working on this repo for another feature addition with a friend, so had the refreshTime set to 30 seconds, and every now and again the display would crash out with a KeyError on `lt7:et`.

```
File "/home/james/train-departure-display/src/trains.py", line 35, in prepareLocationName
    expected_time = location["lt7:et"]
KeyError: 'lt7:et'
```

Did some delving into the API docs and it seems that the API either returns an estimated time, **or** an actual time, hence the crash when it couldn't find the 'et' key.

![image](https://github.com/chrisys/train-departure-display/assets/5637797/1bb2a2ed-1c3a-4ed9-b6bb-3cdb8485d922)


This PR should fix that, I've watched it happen in the last few minutes and the display didn't crash!