### PR TITLE
Added function to parse platform data and filter incorrect data

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,14 @@
 import os
 import re
 
+# validate platform number
+def parsePlatformData(platform):
+    if platform is None:
+        return ""
+    elif bool(re.match(r'^(?:\d{1,2}[A-D]|[A-D]|\d[A-D]?|\d)$', platform)):
+        return platform
+    else:
+        return ""
 
 def loadConfig():
     data = {
@@ -45,14 +53,8 @@ def loadConfig():
     data["journey"]["outOfHoursName"] = os.getenv("outOfHoursName") or "London Paddington"
     data["journey"]["stationAbbr"] = {"International": "Intl."}
     data["journey"]['timeOffset'] = os.getenv("timeOffset") or "0"
-    data["journey"]["screen1Platform"] = os.getenv("screen1Platform") or ""
-    data["journey"]["screen2Platform"] = os.getenv("screen2Platform") or ""
-
-    if data["journey"]["screen1Platform"].isnumeric() is not True:
-        data["journey"]["screen1Platform"] = ""
-
-    if data["journey"]["screen2Platform"].isnumeric() is not True:
-        data["journey"]["screen2Platform"] = ""
+    data["journey"]["screen1Platform"] = parsePlatformData(os.getenv("screen1Platform"))
+    data["journey"]["screen2Platform"] = parsePlatformData(os.getenv("screen2Platform"))
 
     data["api"]["apiKey"] = os.getenv("apiKey") or None
     data["api"]["operatingHours"] = os.getenv("operatingHours") or ""


### PR DESCRIPTION
Another one from me, sorry!

Being in a part of the world with weird platforms (Waterloo East has A-D so as to avoid confusion with Waterloo), I noticed the filter was stripping out anything non-numeric.

I'm not sure if OpenLDBWS supports platforms such as 1A etc, but I have also added support for that into the regex function I've created.

Valid entries are:

- 0-99
- A-D
- 1A-99D

_(yes I know there isn't anywhere with over 24 platforms, but a 2 digit regex is more succinct!)_

Pretty sure there aren't any stations with letters over E, but the code should be straightforward enough to adjust if needs be in the future!